### PR TITLE
Packet callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,3 @@ The XMODEM protocol in Rust
 
 # Testing
 The tests require the binaries found in the `lrzsz` package.
-
-# Rust channels
-Currently only the beta and nightly channels are supported (stable support is waiting on [#27585](https://github.com/rust-lang/rust/issues/27585))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,11 +95,11 @@ impl Xmodem {
         self.errors = 0;
 
         debug!("Starting XMODEM transfer");
-        try!(self.start_send(dev));
+        self.start_send(dev)?;
         debug!("First byte received. Sending stream.");
-        try!(self.send_stream(dev, stream));
+        self.send_stream(dev, stream)?;
         debug!("Sending EOT");
-        try!(self.finish_send(dev));
+        self.finish_send(dev)?;
 
         Ok(())
     }
@@ -123,53 +123,53 @@ impl Xmodem {
         self.errors = 0;
         self.checksum_mode = checksum;
         debug!("Starting XMODEM receive");
-        try!(dev.write(&[match self.checksum_mode {
+        dev.write(&[match self.checksum_mode {
             Checksum::Standard => NAK,
-            Checksum::CRC16 => CRC }]));
+            Checksum::CRC16 => CRC }])?;
         debug!("NCG sent. Receiving stream.");
         let mut packet_num : u8 = 1;
         loop {
-            match try!(get_byte_timeout(dev)) {
+            match get_byte_timeout(dev)? {
                 bt @ Some(SOH) | bt @ Some(STX) => { // Handle next packet
                     let packet_size = match bt {
                         Some(SOH) => 128,
                         Some(STX) => 1024,
                         _ => 0, // Why does the compiler need this?
                     };
-                    let pnum = try!(get_byte(dev)); // specified packet number
-                    let pnum_1c = try!(get_byte(dev)); // same, 1's complemented
+                    let pnum = get_byte(dev)?; // specified packet number
+                    let pnum_1c = get_byte(dev)?; // same, 1's complemented
                     // We'll respond with cancel later if the packet number is wrong
                     let cancel_packet = packet_num != pnum ||  (255-pnum) != pnum_1c;
                     let mut data : Vec<u8> = Vec::new();
                     data.resize(packet_size,0);
-                    try!(dev.read_exact(&mut data));
+                    dev.read_exact(&mut data)?;
                     let success = match self.checksum_mode {
                         Checksum::Standard => {
-                            let recv_checksum = try!(get_byte(dev));
+                            let recv_checksum = get_byte(dev)?;
                             calc_checksum(&data) == recv_checksum },
                         Checksum::CRC16 => {
                             let recv_checksum =
-                                ( (try!(get_byte(dev)) as u16) << 8) +
-                                try!(get_byte(dev)) as u16;
+                                ( (get_byte(dev)? as u16) << 8) +
+                                get_byte(dev)? as u16;
                             calc_crc(&data) == recv_checksum },
                     };
 
                     if cancel_packet {
-                        try!(dev.write(&[CAN]));
-                            try!(dev.write(&[CAN]));
+                        dev.write(&[CAN])?;
+                            dev.write(&[CAN])?;
                         return Err(Error::Canceled)
                     }
                     if success {
                         packet_num = packet_num.wrapping_add(1);
-                        try!(dev.write(&[ACK]));
-                        try!(outstream.write_all(&data));
+                        dev.write(&[ACK])?;
+                        outstream.write_all(&data)?;
                     } else {
-                        try!(dev.write(&[NAK]));
+                        dev.write(&[NAK])?;
                         self.errors += 1;
                     }
                 },
                 Some(EOT) => { // End of file
-                    try!(dev.write(&[ACK]));
+                    dev.write(&[ACK])?;
                     break
                 },
                 Some(_) => {
@@ -188,7 +188,7 @@ impl Xmodem {
     fn start_send<D: Read + Write>(&mut self, dev: &mut D) -> Result<()> {
         let mut cancels = 0u32;
         loop {
-            match try!(get_byte_timeout(dev)) {
+            match get_byte_timeout(dev)? {
                 Some(c) => {
                     match c {
                         NAK => {
@@ -233,7 +233,7 @@ impl Xmodem {
         let mut block_num = 0u32;
         loop {
             let mut buff = vec![self.pad_byte; self.block_length as usize + 3];
-            let n = try!(stream.read(&mut buff[3..]));
+            let n = stream.read(&mut buff[3..])?;
             if n == 0 {
                 debug!("Reached EOF");
                 return Ok(());
@@ -260,9 +260,9 @@ impl Xmodem {
             }
 
             debug!("Sending block {}", block_num);
-            try!(dev.write_all(&buff));
+            dev.write_all(&buff)?;
 
-            match try!(get_byte_timeout(dev)) {
+            match get_byte_timeout(dev)? {
                 Some(c) => {
                     if c == ACK {
                         debug!("Received ACK for block {}", block_num);
@@ -287,9 +287,9 @@ impl Xmodem {
 
     fn finish_send<D: Read + Write>(&mut self, dev: &mut D) -> Result<()> {
         loop {
-            try!(dev.write_all(&[EOT]));
+            dev.write_all(&[EOT])?;
 
-            match try!(get_byte_timeout(dev)) {
+            match get_byte_timeout(dev)? {
                 Some(c) => {
                     if c == ACK {
                         info!("XMODEM transmission successful");
@@ -321,7 +321,7 @@ fn calc_crc(data: &[u8]) -> u16 {
 
 fn get_byte<R: Read>(reader: &mut R) -> std::io::Result<u8> {
     let mut buff = [0];
-    try!(reader.read_exact(&mut buff));
+    reader.read_exact(&mut buff)?;
     Ok(buff[0])
 }
 


### PR DESCRIPTION
Sometimes it takes a lot of time to transfer a file over serial. It is annoying if you have no feedback about the progress (or anything that helps to decide whether the SW is stuck in an infinite loop or doing its job).  
  
So I implemented a callback-feature that notifies the caller about every successful packet transfer.
I also added a builder over `Xmodem `struct, it should not be re-configurable after construction (It is just ugly). So please consider removing `pub` keywords from all the `Xmodem `struct members. People should use a builder or a default config.