### PR TITLE
Updates from Oxide Computer Company

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "xmodem"
-version = "0.1.3"
+version = "0.4.0"
 authors = ["Allen Welkie <allen.welkie@gmail.com>"]
-keywords = ["xmodem", "ymodem", "zmodem", "serial"]
+keywords = ["xmodem", "serial", "no_std"]
 repository = "https://github.com/awelkie/xmodem.rs"
 license = "MIT"
 description = "An implementation of the XMODEM file-transfer protocol."
+edition = "2024"
 
 [dependencies]
-log = "^0.3"
-crc16 = "^0.3"
+log = { version = "0.4", default-features = false }
+crc16 = "0.4"
 
 [dev-dependencies]
-tempfile = "^2.0"
-rand = "^0.3"
+tempfile = "3.0"
+rand = "0.9"
+
+[features]
+std = []
+default = ["std"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
 # XMODEM.rs
 
-[![Build Status](https://travis-ci.org/awelkie/xmodem.rs.svg?branch=master)](https://travis-ci.org/awelkie/xmodem.rs)
-[![](https://img.shields.io/crates/v/xmodem.svg)](https://crates.io/crates/xmodem)
-[![](https://img.shields.io/crates/l/xmodem.svg)](https://crates.io/crates/xmodem)
-
 The XMODEM protocol in Rust
 
-# Testing
-The tests require the binaries found in the `lrzsz` package.
+This is derived from https://github.com/awelkie/xmodem.rs.  It has been modified
+primarily to support `no_std` use and for use with the 2018 edition.  All four
+permutations of standard 128-byte and 1024-byte block sizes, classic and CRC16
+variants are supported for send and receive.  YMODEM and ZMODEM are not
+implemented.  In addition, the `send` and `recv` methods return the number of
+bytes of data sent or received.
 
-# Rust channels
-Currently only the beta and nightly channels are supported (stable support is waiting on [#27585](https://github.com/rust-lang/rust/issues/27585))
+For a `no_std` build, it is necessary to request the `core` feature in addition
+to `--no-default-features` or `default-features = false` on account of
+cargo#1839.  Additionally, your compiler must be known to `core_io`.  Changes
+are welcome to allow the use of alternate crates providing `Read` and `Write`
+traits with the same signatures as those in `std::io`; unfortunately this does
+not include (most of?) the Embedded HAL crates, which provide slightly different
+signatures.
+
+# Testing
+The tests require the binaries found in the `lrzsz` package.  There are no tests
+for the `no_std` build.

--- a/tests/external.rs
+++ b/tests/external.rs
@@ -1,13 +1,13 @@
 //! Test against the `sx` program, and itself
-extern crate tempfile;
 extern crate rand;
+extern crate tempfile;
 extern crate xmodem;
 
-use std::process::{Command, Stdio, ChildStdin, ChildStdout};
-use std::io::{self, Read, Write, Seek};
+use rand::{RngCore, rng};
+use std::io::{self, Read, Seek, Write};
+use std::process::{ChildStdin, ChildStdout, Command, Stdio};
 use tempfile::NamedTempFile;
-use rand::{Rng, thread_rng};
-use xmodem::{Xmodem,Checksum,BlockLength};
+use xmodem::{BlockLength, Checksum, Xmodem};
 
 struct ChildStdInOut {
     stdin: ChildStdin,
@@ -31,9 +31,9 @@ impl Write for ChildStdInOut {
 }
 
 #[cfg(test)]
-fn xmodem_recv(checksum_mode : Checksum, block_length : BlockLength, data_len : usize) {
+fn xmodem_recv(checksum_mode: Checksum, block_length: BlockLength, data_len: usize) {
     let mut data = vec![0; data_len];
-    thread_rng().fill_bytes(&mut data);
+    rng().fill_bytes(&mut data);
 
     let mut send_file = NamedTempFile::new().unwrap();
     send_file.write_all(&data).unwrap();
@@ -41,82 +41,89 @@ fn xmodem_recv(checksum_mode : Checksum, block_length : BlockLength, data_len : 
     let mut send_builder = Command::new("sb");
     send_builder.arg("--xmodem");
     match block_length {
-        BlockLength::OneK => { send_builder.arg("--1k"); }
+        BlockLength::OneK => {
+            send_builder.arg("--1k");
+        }
         _ => {}
     }
-    let send = send_builder.arg(send_file.path())
+    let send = send_builder
+        .arg(send_file.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .spawn().unwrap();
-    
+        .spawn()
+        .unwrap();
+
     let tx_stream = send.stdin.unwrap();
     let rx_stream = send.stdout.unwrap();
-    let mut serial_dev = ChildStdInOut { stdin: tx_stream, stdout: rx_stream };
+    let mut serial_dev = ChildStdInOut {
+        stdin: tx_stream,
+        stdout: rx_stream,
+    };
 
     let mut xmodem = Xmodem::new();
     let mut recv_data = Vec::new();
-    xmodem.recv(&mut serial_dev,&mut recv_data, checksum_mode).unwrap();
+    let bytes = xmodem
+        .recv(&mut serial_dev, &mut recv_data, checksum_mode)
+        .unwrap();
+    assert_eq!(bytes, (data_len + 127) & !127);
 
     let mut sent_data = Vec::new();
     send_file.seek(std::io::SeekFrom::Start(0)).unwrap();
     send_file.read_to_end(&mut sent_data).unwrap();
     let mut padded_data = sent_data.clone();
     for _ in 0..(128 - sent_data.len() % 128) {
-         padded_data.push(0x1a);
+        padded_data.push(0x1a);
     }
     assert_eq!(padded_data, recv_data);
 }
 
 #[test]
 fn xmodem_recv_standard() {
-    xmodem_recv(Checksum::Standard,
-                BlockLength::Standard,
-                2000);
+    xmodem_recv(Checksum::Standard, BlockLength::Standard, 2000);
 }
 
 #[test]
 fn xmodem_recv_crc() {
-    xmodem_recv(Checksum::CRC16,
-                BlockLength::Standard,
-                2000);
+    xmodem_recv(Checksum::CRC16, BlockLength::Standard, 2000);
 }
 
 #[test]
 fn xmodem_recv_1k_crc() {
-    xmodem_recv(Checksum::CRC16,
-                BlockLength::OneK,
-                8500);
+    xmodem_recv(Checksum::CRC16, BlockLength::OneK, 8500);
 }
 
 #[test]
 fn xmodem_recv_long() {
-    xmodem_recv(Checksum::CRC16,
-                BlockLength::Standard,
-                50000);
+    xmodem_recv(Checksum::CRC16, BlockLength::Standard, 50000);
 }
 
 #[test]
 fn xmodem_send_standard() {
     let data_len = 2000;
     let mut data = vec![0; data_len];
-    thread_rng().fill_bytes(&mut data);
+    rng().fill_bytes(&mut data);
 
     let mut recv_file = NamedTempFile::new().unwrap();
     let recv = Command::new("rb")
-                       .arg("--xmodem")
-                       .arg(recv_file.path())
-                       .stdin(Stdio::piped())
-                       .stdout(Stdio::piped())
-                       .stderr(Stdio::null())
-                       .spawn().unwrap();
+        .arg("--xmodem")
+        .arg(recv_file.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
 
     let tx_stream = recv.stdin.unwrap();
     let rx_stream = recv.stdout.unwrap();
-    let mut serial_dev = ChildStdInOut { stdin: tx_stream, stdout: rx_stream };
+    let mut serial_dev = ChildStdInOut {
+        stdin: tx_stream,
+        stdout: rx_stream,
+    };
 
     let mut xmodem = Xmodem::new();
-    xmodem.send(&mut serial_dev, &mut &data[..]).unwrap();
+    let bytes = xmodem.send(&mut serial_dev, &mut &data[..]).unwrap();
+    assert_eq!(bytes, data_len);
 
     let mut received_data = Vec::new();
     recv_file.read_to_end(&mut received_data).unwrap();
@@ -131,21 +138,25 @@ fn xmodem_send_standard() {
 fn xmodem_send_crc() {
     let data_len = 2000;
     let mut data = vec![0; data_len];
-    thread_rng().fill_bytes(&mut data);
+    rng().fill_bytes(&mut data);
 
     let mut recv_file = NamedTempFile::new().unwrap();
     let recv = Command::new("rb")
-                       .arg("--xmodem")
-                       .arg("--with-crc")
-                       .arg(recv_file.path())
-                       .stdin(Stdio::piped())
-                       .stdout(Stdio::piped())
-                       .stderr(Stdio::null())
-                       .spawn().unwrap();
+        .arg("--xmodem")
+        .arg("--with-crc")
+        .arg(recv_file.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
 
     let tx_stream = recv.stdin.unwrap();
     let rx_stream = recv.stdout.unwrap();
-    let mut serial_dev = ChildStdInOut { stdin: tx_stream, stdout: rx_stream };
+    let mut serial_dev = ChildStdInOut {
+        stdin: tx_stream,
+        stdout: rx_stream,
+    };
 
     let mut xmodem = Xmodem::new();
     xmodem.send(&mut serial_dev, &mut &data[..]).unwrap();
@@ -153,7 +164,7 @@ fn xmodem_send_crc() {
     let mut received_data = Vec::new();
     recv_file.read_to_end(&mut received_data).unwrap();
     let mut padded_data = data.clone();
-    
+
     for _ in 0..(128 - data.len() % 128) {
         padded_data.push(0x1a);
     }

--- a/tests/loopback.rs
+++ b/tests/loopback.rs
@@ -1,15 +1,15 @@
 //! Test against own implementation
-extern crate tempfile;
 extern crate rand;
+extern crate tempfile;
 extern crate xmodem;
 
-use std::io::{self, Read, Write, ErrorKind};
-use xmodem::{Xmodem,Checksum,BlockLength};
-use std::sync::mpsc::{channel,Sender,Receiver};
+use std::io::{self, ErrorKind, Read, Write};
+use std::sync::mpsc::{Receiver, Sender, channel};
+use xmodem::{BlockLength, Checksum, Xmodem};
 
 struct BidirectionalPipe {
-    pin : Receiver<u8>,
-    pout : Sender<u8>,
+    pin: Receiver<u8>,
+    pout: Sender<u8>,
 }
 
 impl Read for BidirectionalPipe {
@@ -17,7 +17,7 @@ impl Read for BidirectionalPipe {
         for idx in 0..buf.len() {
             buf[idx] = match self.pin.recv() {
                 Ok(v) => v,
-                Err(e) => return Err(std::io::Error::new(ErrorKind::BrokenPipe,e)),
+                Err(e) => return Err(std::io::Error::new(ErrorKind::BrokenPipe, e)),
             }
         }
         Ok(buf.len())
@@ -26,7 +26,9 @@ impl Read for BidirectionalPipe {
 
 impl Write for BidirectionalPipe {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        for v in buf { self.pout.send(*v).unwrap(); }
+        for v in buf {
+            self.pout.send(*v).unwrap();
+        }
         Ok(buf.len())
     }
 
@@ -36,56 +38,66 @@ impl Write for BidirectionalPipe {
 }
 
 fn loopback() -> (BidirectionalPipe, BidirectionalPipe) {
-    let (s1,r1) = channel();
-    let (s2,r2) = channel();
-    (BidirectionalPipe{ pin : r1, pout : s2 }, BidirectionalPipe{ pin : r2, pout : s1 })
+    let (s1, r1) = channel();
+    let (s2, r2) = channel();
+    (
+        BidirectionalPipe { pin: r1, pout: s2 },
+        BidirectionalPipe { pin: r2, pout: s1 },
+    )
 }
 
 #[cfg(test)]
-fn xmodem_loopback(checksum_mode:Checksum,block_length:BlockLength, data_len : usize) {
+fn xmodem_loopback(checksum_mode: Checksum, block_length: BlockLength, data_len: usize) {
     let mut data_out = vec![0; data_len];
     // We don't really need the rng here
-    for idx in 0..data_len { data_out[idx] = ((idx+7) * 13) as u8; }
+    for idx in 0..data_len {
+        data_out[idx] = ((idx + 7) * 13) as u8;
+    }
     let (mut p1, mut p2) = loopback();
     let handle = std::thread::spawn(move || {
         let mut xmodem = Xmodem::new();
         xmodem.block_length = block_length;
-        xmodem.send(&mut p1, &mut &data_out[..]).unwrap();
-        data_out
+        let bytes_out = xmodem.send(&mut p1, &mut &data_out[..]).unwrap();
+        (data_out, bytes_out)
     });
     let handle2 = std::thread::spawn(move || {
         let mut xmodem = Xmodem::new();
-        let mut data_in= vec![0; 0];
-        xmodem.recv(&mut p2, &mut data_in, checksum_mode).unwrap();
-        data_in
+        let mut data_in = vec![0; 0];
+        let bytes_in = xmodem.recv(&mut p2, &mut data_in, checksum_mode).unwrap();
+        (data_in, bytes_in)
     });
-    
-    let mut dato = handle.join().unwrap();
+
+    let (mut dato, bytes_out) = handle.join().unwrap();
+    assert_eq!(bytes_out, dato.len());
+
     // Pad output data to multiple of block length for comparison
     let bl = block_length as usize;
-    for _ in 0..(bl - data_len % bl) { dato.push(0x1a); }
-    let dati = handle2.join().unwrap();
-    assert_eq!(dato.len(),dati.len());
-    assert_eq!(dato,dati);
+    for _ in 0..(bl - data_len % bl) {
+        dato.push(0x1a);
+    }
+    let (dati, bytes_in) = handle2.join().unwrap();
+    assert_eq!(dato.len(), dati.len());
+    assert_eq!(dato, dati);
+    assert_eq!(bytes_in, dati.len());
 }
 
 #[test]
 fn xmodem_loopback_standard() {
-    xmodem_loopback(Checksum::Standard,BlockLength::Standard,2000);
+    xmodem_loopback(Checksum::Standard, BlockLength::Standard, 2000);
 }
 
 #[test]
 fn xmodem_loopback_onek() {
-    xmodem_loopback(Checksum::Standard,BlockLength::OneK,2200);
+    xmodem_loopback(Checksum::Standard, BlockLength::OneK, 2200);
 }
 
 #[test]
 fn xmodem_loopback_crc() {
-    xmodem_loopback(Checksum::CRC16,BlockLength::Standard,2000);
+    xmodem_loopback(Checksum::CRC16, BlockLength::Standard, 2000);
 }
 
 #[test]
 fn xmodem_loopback_long_crc() {
     // make sure we wrap block counter
-    xmodem_loopback(Checksum::CRC16,BlockLength::Standard,50000);
+    xmodem_loopback(Checksum::CRC16, BlockLength::Standard, 50000);
 }


### PR DESCRIPTION
This commit encompasses changes introduced by Oxide Computer Company:

* Updated implementation to Rust 2024
* Updated dependencies to most recent versions
* Improved `no_std` support
* Removing the `core_io` dependency
* Keeping track of the number of bytes transferred
* Consistent formatting with `rustfmt`
* Fix clippy lints

All tests pass, we have been using this version internally for several years now, and have confidence in the changes.